### PR TITLE
Facebook Open Graph tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 
     <!-- Schema.org markup for Google+ -->
     <meta itemprop="name" content="Cedar Ridge High School - Innovate Create Educate">
-    <meta itemprop="description" content="Independent High School in Kanata Grades 9-12 Personalized learning in a modern open-concept environment.">
+    <meta itemprop="description" content="Independent High School in Kanata Grades 9-12 - a fresh approach to secondary education.">
     <meta itemprop="image" content="img/logos/Cedar_Ridge_Neg_Big.png">
 
 
@@ -51,27 +51,27 @@
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@CedarRidge_HS">
     <meta name="twitter:title" content="Cedar Ridge High School - Innovate Create Educate">
-    <meta name="twitter:description" content="Independent High School in Kanata Grades 9-12 Personalized learning in a modern open-concept environment.">
+    <meta name="twitter:description" content="Independent High School in Kanata Grades 9-12 - a fresh approach to secondary education.">
     <meta name="twitter:creator" content="@CedarRidge_HS">
     <meta name="twitter:image" content="img/background/startup.jpg">
     <!-- /twitter -->
 
 
     <!-- linkedin -->
-    <meta prefix="og: http://ogp.me/ns#" property="og:title" content="Cedar Ridge High School - Innovate Create Educate" />
+    <meta prefix="og: http://ogp.me/ns#" property="og:title" content="cedar ridge HIGH SCHOOL | INNOVATE CREATE EDUCATE" />
     <meta prefix="og: http://ogp.me/ns#" property="og:type" content="website" />
-    <meta prefix="og: http://ogp.me/ns#" property="og:image" content="img/background/startup.jpg" />
+    <meta prefix="og: http://ogp.me/ns#" property="og:image" content="http://www.cedarridgehighschool.ca/img/background/startup.jpg" />
     <meta prefix="og: http://ogp.me/ns#" property="og:url" content="http://www.cedarridgehighschool.ca/" />
     <!-- linkedin -->
 
 
-    <!-- facebook(opengraph) -->
+    <!-- facebook(opengraph) 
     <meta property="og:title" content="Cedar Ridge High School - Innovate Create Educate" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="http://www.cedarridgehighschool.ca/" />
-    <meta property="og:image" content="img/background/startup.jpg" />
-    <meta property="og:description" content="Independent High School in Kanata Grades 9-12 Personalized learning in a modern open-concept environment."/>
-    <meta property="business:contact_data:street_address" content="275 Michael Cowpland Dr." />
+    <meta property="og:image" content="img/background/startup.jpg" /> -->
+    <meta property="og:description" content="Independent High School in Kanata Grades 9-12 - a fresh approach to secondary education."/>
+    <!--<meta property="business:contact_data:street_address" content="275 Michael Cowpland Dr." />
     <meta property="business:contact_data:locality" content="Kanata" />
     <meta property="business:contact_data:postal_code" content="K2M 2G2" />
     <meta property="business:contact_data:region" content="Ontario" />
@@ -80,7 +80,7 @@
     <meta property="business:contact_data:phone_number" content="613-592-9019" />
     <meta property="business:contact_data:website" content="http://www.cedarridgehighschool.ca/" />
     <meta property="place:location:latitude" content="45.284536" />
-    <meta property="place:location:longitude" content="-75.874517" />
+    <meta property="place:location:longitude" content="-75.874517" />-->
     <!-- /facebook(opengraph) -->
 
 </head>


### PR DESCRIPTION
### Why

Fixes #130

### What

updated tags to remove warnings and ensure the right picture, title and
description is shared when a link to this url is posted in Facebook